### PR TITLE
Added lxml to pipfile, needed for matplotlib on some machines

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ matplotlib = "*"
 jupyter = "*"
 pandas = "*"
 autopep8 = "*"
+lxml = "*"
 
 [requires]
 python_version = "3.6"


### PR DESCRIPTION
On some systems, lxml doesn't get packaged with matplotlib